### PR TITLE
Rain-13354: use unversioned memmove to aid arm64 compilation

### DIFF
--- a/pcap.go
+++ b/pcap.go
@@ -9,17 +9,12 @@ package pcap
 #include <ifaddrs.h>
 
 #ifdef  __GLIBC__
-// See this for glibc 2.14 hack below
-// https://www.win.tue.nl/~aeb/linux/misc/gcc-semibug.html
-
-void *__memcpy_glibc_2_2_5(void *, const void *, size_t);
-
 // We use memmove rather than memcpy here since it is safer
 // for overlapping memory regions.
-asm(".symver __memcpy_glibc_2_2_5, memmove@GLIBC_2.2.5");
+
 void *__wrap_memcpy(void *dest, const void *src, size_t n)
 {
-    return __memcpy_glibc_2_2_5(dest, src, n);
+    return memmove(dest, src, n);
 }
 #endif
 #define MAX_PACKETS     10
@@ -97,13 +92,14 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/lacework/agent/datacollector/dlog"
 	"io/ioutil"
 	"net"
 	"strings"
 	"syscall"
 	"time"
 	"unsafe"
+
+	"github.com/lacework/agent/datacollector/dlog"
 )
 
 type Pcap struct {


### PR DESCRIPTION
memmove_2.2.5 was being used till now. The glibc had issues with memcpy where memcpy_2.14 was mandated so the machines having older glibc versions were getting erorrs. But there has been no history of issues with memmove so we should be able to use unversioned
Just a side note, glibc2.14 was release 9 yrs ago and the current version is 2.32. We shouldn't expect issues with machines running pre 2.14.
RAIN-13354