### PR TITLE
Revert "Rain-13354: use unversioned memmove to aid arm64 compilation"

### DIFF
--- a/pcap.go
+++ b/pcap.go
@@ -9,12 +9,17 @@ package pcap
 #include <ifaddrs.h>
 
 #ifdef  __GLIBC__
+// See this for glibc 2.14 hack below
+// https://www.win.tue.nl/~aeb/linux/misc/gcc-semibug.html
+
+void *__memcpy_glibc_2_2_5(void *, const void *, size_t);
+
 // We use memmove rather than memcpy here since it is safer
 // for overlapping memory regions.
-
+asm(".symver __memcpy_glibc_2_2_5, memmove@GLIBC_2.2.5");
 void *__wrap_memcpy(void *dest, const void *src, size_t n)
 {
-    return memmove(dest, src, n);
+    return __memcpy_glibc_2_2_5(dest, src, n);
 }
 #endif
 #define MAX_PACKETS     10
@@ -92,14 +97,13 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/lacework/agent/datacollector/dlog"
 	"io/ioutil"
 	"net"
 	"strings"
 	"syscall"
 	"time"
 	"unsafe"
-
-	"github.com/lacework/agent/datacollector/dlog"
 )
 
 type Pcap struct {


### PR DESCRIPTION
Reverts lacework/pcap#1