### PR TITLE
amd64 uses memmove_2.2.5, arm64 uses just memmove

### DIFF
--- a/memmove_linux_amd64.go
+++ b/memmove_linux_amd64.go
@@ -1,0 +1,26 @@
+// Package pcap is a wrapper around the pcap library.
+package pcap
+
+/*
+#cgo LDFLAGS: -Wl,-Bstatic -lpcap -Wl,-Bdynamic,--wrap=memcpy
+#include <stdlib.h>
+#include <pcap.h>
+#include <string.h>
+#include <ifaddrs.h>
+
+#ifdef  __GLIBC__
+// See this for glibc 2.14 hack below
+// https://www.win.tue.nl/~aeb/linux/misc/gcc-semibug.html
+void *__memcpy_glibc_2_2_5(void *, const void *, size_t);
+
+// We use memmove rather than memcpy here since it is safer
+// for overlapping memory regions.
+asm(".symver __memcpy_glibc_2_2_5, memmove@GLIBC_2.2.5");
+
+void *__wrap_memcpy(void *dest, const void *src, size_t n)
+{
+  	return __memcpy_glibc_2_2_5(dest, src, n);
+}
+#endif
+*/
+import "C"

--- a/memmove_linux_arm64.go
+++ b/memmove_linux_arm64.go
@@ -1,0 +1,21 @@
+// Package pcap is a wrapper around the pcap library.
+package pcap
+
+/*
+#cgo LDFLAGS: -Wl,-Bstatic -lpcap -Wl,-Bdynamic,--wrap=memcpy
+#include <stdlib.h>
+#include <pcap.h>
+#include <string.h>
+#include <ifaddrs.h>
+
+#ifdef  __GLIBC__
+// We use memmove rather than memcpy here since it is safer
+// for overlapping memory regions.
+
+void *__wrap_memcpy(void *dest, const void *src, size_t n)
+{
+    return memmove(dest, src, n);
+}
+#endif
+*/
+import "C"

--- a/pcap.go
+++ b/pcap.go
@@ -8,15 +8,6 @@ package pcap
 #include <string.h>
 #include <ifaddrs.h>
 
-#ifdef  __GLIBC__
-// We use memmove rather than memcpy here since it is safer
-// for overlapping memory regions.
-
-void *__wrap_memcpy(void *dest, const void *src, size_t n)
-{
-    return memmove(dest, src, n);
-}
-#endif
 #define MAX_PACKETS     10
 #define PCAP_DISPATCH_OVERFLOW 5
 #define MAX_PKT_CAPLEN  576


### PR DESCRIPTION
compiles on both amd64 and arm64 hosts